### PR TITLE
remove anaconda channel

### DIFF
--- a/workflow/envs/sc_e2g.yml
+++ b/workflow/envs/sc_e2g.yml
@@ -3,7 +3,6 @@ channels:
   - bioconda
   - conda-forge
   - defaults
-  - anaconda
   - r
 dependencies:
   - bedtools=2.29.2


### PR DESCRIPTION
remove unnecessary channel specification from environment config file which caused errors on Sherlock

