### PR TITLE
Write the ABC biosample config only when its content changes

### DIFF
--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -1,3 +1,7 @@
+import filecmp
+import tempfile
+
+
 ## Update paths in the config obj to absolute path
 def make_paths_absolute(obj, base_path):
 	"""
@@ -23,6 +27,18 @@ def make_biosample_config(cluster_config, biosample_config, results_dir):
 	It is designed for use in the ABC pipeline. In this context, each cell cluster is treated as an individual biosample.
 	Additionally, the function sets up necessary file paths and directories for the biosample data.
 
+	This function is called at parse time, so it runs on every single Snakemake
+	invocation -- including `--dry-run`, `--unlock`, and each remote job's
+	re-parse on a compute node. The biosample config it produces is a declared
+	input of downstream rules (e.g. ENCODE_rE2G's make_biosample_feature_table),
+	so rewriting it unconditionally would refresh its mtime on every invocation
+	and make Snakemake consider the whole downstream DAG out of date, even when
+	nothing changed. It is therefore written "if changed": the table is rendered
+	to a temporary file and only moved into place when it differs from what is
+	already there, leaving the mtime alone for no-op invocations while still
+	updating (and correctly triggering reruns) whenever the cluster config
+	really does change.
+
 	:param cluster_config: Path to the input cell cluster configuration file.
 	:param biosample_config: Path for the output biosample configuration file.
 	:param results_dir: Directory where result files are stored.
@@ -45,7 +61,34 @@ def make_biosample_config(cluster_config, biosample_config, results_dir):
 	if not os.path.exists(output_dir):
 		os.makedirs(output_dir)
 
-	df.to_csv(biosample_config, sep='\t', index=False)
+	# Render to a temporary file in the destination directory, so the bytes
+	# compared below are produced by exactly the same code path that would
+	# write the final file, and so the move into place is atomic.
+	tmp_fd, tmp_path = tempfile.mkstemp(
+		dir=output_dir,
+		prefix=os.path.basename(biosample_config) + ".",
+		suffix=".tmp"
+	)
+	os.close(tmp_fd)
+	try:
+		# mkstemp() is deliberately 0600; restore the permissions a plain
+		# open() would have given the file so group-shared results stay readable.
+		umask = os.umask(0)
+		os.umask(umask)
+		os.chmod(tmp_path, 0o666 & ~umask)
+
+		df.to_csv(tmp_path, sep='\t', index=False)
+
+		# Unchanged content: leave the existing file (and its mtime) untouched.
+		if os.path.exists(biosample_config) and filecmp.cmp(tmp_path, biosample_config, shallow=False):
+			return
+
+		# First run, or the content really changed: publish atomically.
+		os.replace(tmp_path, biosample_config)
+		tmp_path = None
+	finally:
+		if tmp_path is not None and os.path.exists(tmp_path):
+			os.remove(tmp_path)
 
 
 ## Import configuration for ENCODE_rE2G


### PR DESCRIPTION
make_biosample_config() is called from workflow/Snakefile at parse time, so it runs on every single Snakemake invocation: real runs, `--dry-run`, `--unlock`, `--list`, and each remote job's re-parse on a compute node. It unconditionally called df.to_csv() on {results_dir}/tmp/config_abc_biosamples.tsv, which refreshed that file's mtime even when the rendered table was byte-for-byte identical to what was already there.

That file is a declared input of ENCODE_rE2G's make_biosample_feature_table rule, so under Snakemake's default rerun-triggers the fresh mtime cascaded staleness through essentially the whole downstream DAG. In practice this meant a restart wanted to re-run 130 of 159 jobs when only 14 were genuinely outstanding, and merely *inspecting* a finished run with `--dry-run` was enough to dirty it. Dropping mtime from --rerun-triggers did not help, because the "input files updated" trigger fires off the same stat; only the blunt `--rerun-triggers code` avoided it, at the cost of disabling legitimate rerun detection.

Make the write idempotent instead. The table is rendered to a temporary file in the destination directory and only moved into place when it differs from the existing file, so a no-op invocation leaves both the content and the mtime alone. Rendering through the same pandas to_csv() file path guarantees the bytes are unchanged from before this commit; publishing with os.replace() makes the update atomic, which also removes the previous risk of concurrent parses on different compute nodes observing a half-written config. A genuine change to the cell cluster config still rewrites the file and still triggers the reruns it should.